### PR TITLE
Fix signature issues

### DIFF
--- a/Model/Indexer/Fulltext/Action/IndexIterator.php
+++ b/Model/Indexer/Fulltext/Action/IndexIterator.php
@@ -143,7 +143,7 @@ class IndexIterator implements \Iterator
      * @deprecated 100.1.6 Since class is deprecated
      * @since 100.0.3
      */
-    public function current()
+    public function current(): mixed
     {
         return $this->current;
     }
@@ -154,7 +154,7 @@ class IndexIterator implements \Iterator
      * @deprecated 100.1.6 Since class is deprecated
      * @since 100.0.3
      */
-    public function next()
+    public function next(): void
     {
         \next($this->products);
         if (\key($this->products) === null) {
@@ -253,7 +253,7 @@ class IndexIterator implements \Iterator
      * @deprecated 100.1.6 Since class is deprecated
      * @since 100.0.3
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->key;
     }
@@ -264,7 +264,7 @@ class IndexIterator implements \Iterator
      * @deprecated 100.1.6 Since class is deprecated
      * @since 100.0.3
      */
-    public function valid()
+    public function valid(): bool
     {
         return $this->isValid;
     }
@@ -275,7 +275,7 @@ class IndexIterator implements \Iterator
      * @deprecated 100.1.6 Since class is deprecated
      * @since 100.0.3
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->lastProductId = 0;
         $this->key = null;

--- a/Model/Indexer/Fulltext/Action/IndexIterator.php
+++ b/Model/Indexer/Fulltext/Action/IndexIterator.php
@@ -143,7 +143,8 @@ class IndexIterator implements \Iterator
      * @deprecated 100.1.6 Since class is deprecated
      * @since 100.0.3
      */
-    public function current(): mixed
+    #[\ReturnTypeWillChange]
+    public function current()
     {
         return $this->current;
     }
@@ -253,7 +254,8 @@ class IndexIterator implements \Iterator
      * @deprecated 100.1.6 Since class is deprecated
      * @since 100.0.3
      */
-    public function key(): mixed
+    #[\ReturnTypeWillChange]
+    public function key()
     {
         return $this->key;
     }


### PR DESCRIPTION
There were some additional issues with PHP 8.1: The signature of a class was incorrect, so I fixed it for myself. But but but, the return type `mixed` which was required for my fix is **ONLY** compatible with PHP 8: https://www.php.net/manual/en/language.types.declarations.php#language.types.declarations.mixed So I guess this is not something to include in the release. Any smart ideas of including this fix for PHP 8.1 while including the old file for PHP 7?